### PR TITLE
feat: streaming transcript + silence detection (phases 1.3 & 1.4)

### DIFF
--- a/src/hooks/useSpeechRecognition.ts
+++ b/src/hooks/useSpeechRecognition.ts
@@ -1,51 +1,130 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useRef, useCallback } from "react";
 import {
   ExpoSpeechRecognitionModule,
   useSpeechRecognitionEvent,
 } from "@jamsch/expo-speech-recognition";
 
-export function useSpeechRecognition() {
-  const [transcript, setTranscript] = useState("");
+const SILENCE_TIMEOUT_MS = 1500;
+const DEFAULT_LANG = "fr-FR";
+
+export interface SpeechRecognitionOptions {
+  lang?: string;
+  silenceTimeoutMs?: number;
+  onSilenceDetected?: (finalTranscript: string) => void;
+}
+
+export function useSpeechRecognition(options?: SpeechRecognitionOptions) {
+  const {
+    lang = DEFAULT_LANG,
+    silenceTimeoutMs = SILENCE_TIMEOUT_MS,
+    onSilenceDetected,
+  } = options ?? {};
+
+  const [finalTranscript, setFinalTranscript] = useState("");
+  const [interimTranscript, setInterimTranscript] = useState("");
   const [isListening, setIsListening] = useState(false);
+  const [lastSubmitted, setLastSubmitted] = useState("");
+
+  const silenceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const finalTranscriptRef = useRef("");
+
+  const clearSilenceTimer = useCallback(() => {
+    if (silenceTimerRef.current) {
+      clearTimeout(silenceTimerRef.current);
+      silenceTimerRef.current = null;
+    }
+  }, []);
+
+  const submitTranscript = useCallback(() => {
+    const text = finalTranscriptRef.current.trim();
+    if (!text) return;
+
+    console.log("[STT] Silence detected — submitting transcript:", text);
+    setLastSubmitted(text);
+    onSilenceDetected?.(text);
+
+    ExpoSpeechRecognitionModule.stop();
+  }, [onSilenceDetected]);
+
+  const resetSilenceTimer = useCallback(() => {
+    clearSilenceTimer();
+    silenceTimerRef.current = setTimeout(submitTranscript, silenceTimeoutMs);
+  }, [clearSilenceTimer, submitTranscript, silenceTimeoutMs]);
 
   useSpeechRecognitionEvent("start", () => {
     setIsListening(true);
+    setFinalTranscript("");
+    setInterimTranscript("");
+    finalTranscriptRef.current = "";
   });
 
   useSpeechRecognitionEvent("end", () => {
     setIsListening(false);
+    setInterimTranscript("");
+    clearSilenceTimer();
   });
 
   useSpeechRecognitionEvent("result", (event) => {
-    const lastResult = event.results[event.results.length - 1];
-    if (lastResult) {
-      setTranscript(lastResult.transcript);
+    const bestTranscript = event.results[0]?.transcript ?? "";
+
+    if (event.isFinal) {
+      const updated = finalTranscriptRef.current
+        ? `${finalTranscriptRef.current} ${bestTranscript}`
+        : bestTranscript;
+      finalTranscriptRef.current = updated;
+      setFinalTranscript(updated);
+      setInterimTranscript("");
+      resetSilenceTimer();
+    } else {
+      setInterimTranscript(bestTranscript);
+      resetSilenceTimer();
     }
   });
 
   useSpeechRecognitionEvent("error", (event) => {
     console.warn("Speech recognition error:", event.error, event.message);
     setIsListening(false);
+    clearSilenceTimer();
   });
 
   const start = useCallback(async () => {
-    const { granted } = await ExpoSpeechRecognitionModule.requestPermissionsAsync();
+    const { granted } =
+      await ExpoSpeechRecognitionModule.requestPermissionsAsync();
     if (!granted) {
       console.warn("Speech recognition permission not granted");
       return;
     }
 
+    setLastSubmitted("");
+
     ExpoSpeechRecognitionModule.start({
-      lang: "fr-FR",
+      lang,
       continuous: true,
       requiresOnDeviceRecognition: true,
       interimResults: true,
     });
-  }, []);
+  }, [lang]);
 
   const stop = useCallback(() => {
+    clearSilenceTimer();
     ExpoSpeechRecognitionModule.stop();
-  }, []);
+  }, [clearSilenceTimer]);
 
-  return { transcript, isListening, start, stop };
+  return {
+    /** Accumulated final (confirmed) transcript segments */
+    finalTranscript,
+    /** Current interim (in-progress) transcript */
+    interimTranscript,
+    /** Full display transcript: final + interim combined */
+    transcript: interimTranscript
+      ? finalTranscript
+        ? `${finalTranscript} ${interimTranscript}`
+        : interimTranscript
+      : finalTranscript,
+    isListening,
+    /** Last transcript submitted via silence detection */
+    lastSubmitted,
+    start,
+    stop,
+  };
 }

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import { StatusBar } from "expo-status-bar";
 import {
   StyleSheet,
@@ -9,7 +10,24 @@ import {
 import { useSpeechRecognition } from "../hooks/useSpeechRecognition";
 
 export default function HomeScreen() {
-  const { transcript, isListening, start, stop } = useSpeechRecognition();
+  const handleSilenceDetected = useCallback((transcript: string) => {
+    console.log("[LLM] Would send to LLM:", transcript);
+  }, []);
+
+  const {
+    finalTranscript,
+    interimTranscript,
+    isListening,
+    lastSubmitted,
+    start,
+    stop,
+  } = useSpeechRecognition({
+    lang: "fr-FR",
+    silenceTimeoutMs: 1500,
+    onSilenceDetected: handleSilenceDetected,
+  });
+
+  const hasTranscript = finalTranscript || interimTranscript;
 
   return (
     <View style={styles.container}>
@@ -20,10 +38,29 @@ export default function HomeScreen() {
         style={styles.transcriptBox}
         contentContainerStyle={styles.transcriptContent}
       >
-        <Text style={styles.transcriptText}>
-          {transcript || "Appuyez sur le micro pour parler…"}
-        </Text>
+        {hasTranscript ? (
+          <Text style={styles.transcriptText}>
+            {finalTranscript}
+            {interimTranscript ? (
+              <Text style={styles.interimText}>
+                {finalTranscript ? " " : ""}
+                {interimTranscript}
+              </Text>
+            ) : null}
+          </Text>
+        ) : (
+          <Text style={styles.placeholderText}>
+            Appuyez sur le micro pour parler…
+          </Text>
+        )}
       </ScrollView>
+
+      {lastSubmitted ? (
+        <View style={styles.submittedBox}>
+          <Text style={styles.submittedLabel}>Envoyé au LLM :</Text>
+          <Text style={styles.submittedText}>{lastSubmitted}</Text>
+        </View>
+      ) : null}
 
       <Pressable
         style={[styles.micButton, isListening && styles.micButtonActive]}
@@ -65,15 +102,46 @@ const styles = StyleSheet.create({
     width: "100%",
     backgroundColor: "#111",
     borderRadius: 12,
-    marginBottom: 32,
+    marginBottom: 16,
   },
   transcriptContent: {
     padding: 16,
   },
   transcriptText: {
-    color: "#ccc",
+    color: "#fff",
     fontSize: 16,
     lineHeight: 24,
+  },
+  interimText: {
+    color: "#888",
+    fontStyle: "italic",
+  },
+  placeholderText: {
+    color: "#555",
+    fontSize: 16,
+    lineHeight: 24,
+    fontStyle: "italic",
+  },
+  submittedBox: {
+    width: "100%",
+    backgroundColor: "#0a2a1a",
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 32,
+    borderWidth: 1,
+    borderColor: "#1a4a2a",
+  },
+  submittedLabel: {
+    color: "#4caf50",
+    fontSize: 12,
+    fontWeight: "bold",
+    marginBottom: 4,
+    textTransform: "uppercase",
+  },
+  submittedText: {
+    color: "#c8e6c9",
+    fontSize: 14,
+    lineHeight: 20,
   },
   micButton: {
     width: 72,


### PR DESCRIPTION
## Summary

- **Phase 1.3 — Continuous listening → streaming transcript in UI**: Enhanced `useSpeechRecognition` hook to track final vs interim transcripts separately. Final segments accumulate in white text, interim (in-progress) text displays in gray italic — giving real-time visual feedback as the user speaks. Language is configurable (default `fr-FR`).

- **Phase 1.4 — Silence detection: stop on pause, send to LLM**: Added a configurable silence timer (default 1.5s). When the user pauses speaking, recognition auto-stops and the final transcript is submitted via `onSilenceDetected` callback. The submitted text displays in a green "Envoyé au LLM" box in the UI, and is logged to console for future Phase 2 LLM integration.

### Key changes
- `useSpeechRecognition` hook now accepts `SpeechRecognitionOptions` (lang, silenceTimeoutMs, onSilenceDetected callback)
- Returns `finalTranscript`, `interimTranscript`, `transcript` (combined), `lastSubmitted`
- `requiresOnDeviceRecognition: true` preserved — no audio leaves the device
- TypeScript strict, zero warnings

## Test plan
- [ ] Start listening → verify interim text appears in gray italic as you speak
- [ ] Continue speaking → verify final segments accumulate in white
- [ ] Pause speaking for ~1.5s → verify listening auto-stops
- [ ] Verify "Envoyé au LLM" box shows the submitted transcript
- [ ] Check console for `[STT] Silence detected` and `[LLM] Would send to LLM` logs
- [ ] Manual stop via button still works during active listening

🤖 Generated with [Claude Code](https://claude.com/claude-code)